### PR TITLE
switch relay signer versiones

### DIFF
--- a/roles/lacchain-writer-node/tasks/install-relay-signer.yaml
+++ b/roles/lacchain-writer-node/tasks/install-relay-signer.yaml
@@ -8,7 +8,16 @@
   git:
         repo: "https://github.com/LACNetNetworks/gas-management.git"
         dest: "/root/lacchain/gas-relay-signer"
-  when: not relay_signer.stat.exists 
+        version: v1.0.1
+  when: (networkT == '1' and not relay_signer.stat.exists) 
+
+- name: Download Relay Signer code
+  git:
+        repo: "https://github.com/LACNetNetworks/gas-management.git"
+        dest: "/root/lacchain/gas-relay-signer"
+        version: v1.0.0
+  when: (networkT == '0' and not relay_signer.stat.exists) 
+
 
 - name: semanage gas-relay-signer service on centos8
   shell: semanage fcontext -a -t bin_t '/root/lacchain/gas-relay-signer/gas-relay-signer'

--- a/roles/lacchain-writer-node/vars/main.yml
+++ b/roles/lacchain-writer-node/vars/main.yml
@@ -16,7 +16,7 @@ statsserver_legacyprotestnet: http://35.236.236.77:3000
 time: '{{lookup(''pipe'',''date "+%Y-%m-%d %H:%M:%S"'')}}'
 
 # contract address
-relayhub_address_openprotestnet: "0xAa135C93dD05dFBEdb6E0cCDd7f848Df7A43505e"
+relayhub_address_openprotestnet: "0xa4B5eE2906090ce2cDbf5dfff944db26f397037D"
 relayhub_address_mainnet: "0x7a4363E55Ef04e9144a2B187ACA804631A3155B5"
 relayhub_address_legacyprotestnet: "0xd4C70F66714D93a4f6553d379288e84bC45053da"
 


### PR DESCRIPTION
deploy relay-signer v1.0.0 on mainnet and v1.0.1 on protestnet