### PR TITLE
feat(testnet): Besu 23.10.2 + tx-pool=legacy en open-protestnet (writer/boot/validator)

### DIFF
--- a/roles/lacchain-bootnode/tasks/main.yml
+++ b/roles/lacchain-bootnode/tasks/main.yml
@@ -14,6 +14,11 @@
     msg: "legacy-protestnet (networkT='2') was deprecated and removed. Choose mainnet-omega (0) or open-protestnet (1)."
   when: (networkT == '2')
 
+- name: setting besu version (open-protestnet / testnet)
+  set_fact:
+    besu_release_version: "23.10.2"
+  when: (networkT == '1')
+
 - name: Deploying node
   debug:
     msg: You are deploying a BOOT on {{network}}

--- a/roles/lacchain-bootnode/tasks/update-besu.yaml
+++ b/roles/lacchain-bootnode/tasks/update-besu.yaml
@@ -69,5 +69,14 @@
     dest: ~/lacchain/data/genesis.json
     mode: 0755
 
+- name: ensure tx-pool=legacy in config.toml (open-protestnet / testnet)
+  lineinfile:
+    path: ~/lacchain/config.toml
+    regexp: '^\s*tx-pool\s*='
+    line: 'tx-pool="legacy"'
+    insertafter: '^min-gas-price='
+    state: present
+  when: (networkT == '1')
+
 - name: clearing unnecessary folders
   shell: rm -rf /tmp/transit /tmp/besu

--- a/roles/lacchain-bootnode/templates/pantheon-config-openprotestnet.j2
+++ b/roles/lacchain-bootnode/templates/pantheon-config-openprotestnet.j2
@@ -21,6 +21,9 @@ bootnodes=["enode://2ef018fceeac5def4d0c1233235e23351eb0881f4f42ac2a6aec8250cd21
 # Gas
 min-gas-price=0
 
+# Transaction pool
+tx-pool="legacy"
+
 #Metrics
 metrics-push-enabled=true
 metrics-push-port=9091

--- a/roles/lacchain-validator-node/tasks/main.yml
+++ b/roles/lacchain-validator-node/tasks/main.yml
@@ -14,6 +14,11 @@
     msg: "legacy-protestnet (networkT='2') was deprecated and removed. Choose mainnet-omega (0) or open-protestnet (1)."
   when: (networkT == '2')
 
+- name: setting besu version (open-protestnet / testnet)
+  set_fact:
+    besu_release_version: "23.10.2"
+  when: (networkT == '1')
+
 - name: Deploying node
   debug:
     msg: You are deploying a VALIDATOR on {{network}}

--- a/roles/lacchain-validator-node/tasks/update-besu.yaml
+++ b/roles/lacchain-validator-node/tasks/update-besu.yaml
@@ -67,7 +67,16 @@
   copy:
     src: "{{ role_path }}/files/genesis-{{network}}.json"
     dest: ~/lacchain/data/genesis.json
-    mode: 0755    
+    mode: 0755
+
+- name: ensure tx-pool=legacy in config.toml (open-protestnet / testnet)
+  lineinfile:
+    path: ~/lacchain/config.toml
+    regexp: '^\s*tx-pool\s*='
+    line: 'tx-pool="legacy"'
+    insertafter: '^min-gas-price='
+    state: present
+  when: (networkT == '1')
 
 - name: clearing unnecessary folders
   shell: rm -rf /tmp/transit /tmp/besu

--- a/roles/lacchain-validator-node/templates/pantheon-config-openprotestnet.j2
+++ b/roles/lacchain-validator-node/templates/pantheon-config-openprotestnet.j2
@@ -19,6 +19,9 @@ bootnodes=["enode://2ef018fceeac5def4d0c1233235e23351eb0881f4f42ac2a6aec8250cd21
 # Gas
 min-gas-price=0
 
+# Transaction pool
+tx-pool="legacy"
+
 #Metrics
 metrics-push-enabled=true
 metrics-push-port=9091

--- a/roles/lacchain-writer-node/tasks/main.yml
+++ b/roles/lacchain-writer-node/tasks/main.yml
@@ -14,6 +14,11 @@
     msg: "legacy-protestnet (networkT='2') was deprecated and removed. Choose mainnet-omega (0) or open-protestnet (1)."
   when: (networkT == '2')
 
+- name: setting besu version (open-protestnet / testnet)
+  set_fact:
+    besu_release_version: "23.10.2"
+  when: (networkT == '1')
+
 - name: Deploying node
   debug:
     msg: You are deploying a WRITER on {{network}}

--- a/roles/lacchain-writer-node/tasks/update-besu.yaml
+++ b/roles/lacchain-writer-node/tasks/update-besu.yaml
@@ -69,5 +69,14 @@
     dest: ~/lacchain/data/genesis.json
     mode: 0755
 
+- name: ensure tx-pool=legacy in config.toml (open-protestnet / testnet)
+  lineinfile:
+    path: ~/lacchain/config.toml
+    regexp: '^\s*tx-pool\s*='
+    line: 'tx-pool="legacy"'
+    insertafter: '^min-gas-price='
+    state: present
+  when: (networkT == '1')
+
 - name: clearing unnecessary folders
   shell: rm -rf /tmp/transit /tmp/besu

--- a/roles/lacchain-writer-node/templates/pantheon-config-openprotestnet.j2
+++ b/roles/lacchain-writer-node/templates/pantheon-config-openprotestnet.j2
@@ -21,6 +21,9 @@ bootnodes=["enode://2ef018fceeac5def4d0c1233235e23351eb0881f4f42ac2a6aec8250cd21
 # Gas
 min-gas-price=0
 
+# Transaction pool
+tx-pool="legacy"
+
 #Metrics
 metrics-push-enabled=true
 metrics-push-port=9091


### PR DESCRIPTION
## Qué hace

Para la red **open-protestnet / testnet** (`networkT == '1'`), en los 3 roles de nodo (`writer`, `boot`, `validator`):

1. **Fija Besu `23.10.2`** vía `set_fact besu_release_version` en cada `tasks/main.yml`. Cubre **instalación nueva** y **actualización** (el `main.yml` corre antes de `install.yaml` y `update.yaml`).
2. **Fija `tx-pool="legacy"`** en el `config.toml`:
   - **Install:** añadido a las plantillas `pantheon-config-openprotestnet.j2`.
   - **Update:** tarea idempotente `lineinfile` en `update-besu.yaml` (entre `stop` y `start`), que inserta o **corrige** el valor sin re-renderizar el resto del config.

## Alcance

- **testnet (networkT=1):** Besu 23.10.2 + `tx-pool=legacy`.
- **mainnet (networkT=0):** intacto (default `23.4.1` del inventory; sin tocar el pool).
- **Java:** sin cambios (`23.10.2` → major 23 → Java 17).

## Motivación

- **23.10.2** habilita reemplazo/cancelación de tx a `gasPrice 0` en redes gasless (fix upstream PR #6079: `>` → `>=`), imposible en 23.4.1.
- **`tx-pool=legacy`** mantiene la retención ~13h (tope 4096 tx), útil para el monitoreo de tx atascadas. No afecta el reemplazo (eso lo habilita la versión).

## Validación end-to-end (VM real de prueba, clon del nodo dev)

Probado en una VM GCP idéntica al dev (Ubuntu 24.04, c2-standard-4):

- **Install nuevo** (`site-lacchain-node.yml`, writer/testnet) → `web3_clientVersion = besu/v23.10.2`, `config.toml` con `tx-pool="legacy"`, servicio `pantheon` active.
- **Update** (`site-lacchain-update-node.yml`) partiendo de `tx-pool="layered"` → la tarea `lineinfile` lo **corrigió** a `legacy`, versión 23.10.2, servicio active. `PLAY RECAP: failed=0`.

## Nota de rollout

Actualizar **un nodo a la vez** con `site-lacchain-update-node.yml` (`networkT=1`), empezando por un writer no crítico; validators al final para no arriesgar el quórum IBFT2.